### PR TITLE
fix: Fixed text file encoding issue when downloading result

### DIFF
--- a/apps/web/public/locales/ko/form.json
+++ b/apps/web/public/locales/ko/form.json
@@ -9,7 +9,7 @@
     "label": {
       "job": "직업",
       "nation": "거주 국가",
-      "difficulty": "난이도",
+      "difficulty": "면접 난이도",
       "years-of-experience": "경력",
       "go-to-resume-page": "이력서 페이지로 이동하기",
       "not-selected": "값을 선택하지 않았습니다!"

--- a/apps/web/src/modules/form/components/index.module.scss
+++ b/apps/web/src/modules/form/components/index.module.scss
@@ -1,5 +1,6 @@
 @import 'shared-ui/src/index.scss';
 @import '../../../page.module.scss';
+
 // Form page's container responsive width
 @mixin responsive-web {
   width: 400px;
@@ -24,6 +25,7 @@
   gap: 2rem;
   width: 100%;
   align-items: center;
+  padding-bottom: 10vh;
 
   @media screen and (max-width: $breakpoint-small) {
     padding-top: 10vh;

--- a/apps/web/src/modules/result/components/Result.tsx
+++ b/apps/web/src/modules/result/components/Result.tsx
@@ -32,7 +32,7 @@ const Result = ({ resumeData }: ResultProps) => {
         })}${getNewline()}${getNewline()}`;
       })
       .join('');
-    exportAsTextFile({ fileName: 'generated-qa', data: parsedResumeDataToDownload });
+    exportAsTextFile({ fileName: 'generated-qa', text: parsedResumeDataToDownload });
   };
 
   return (

--- a/packages/shared-lib/utils/file/text.ts
+++ b/packages/shared-lib/utils/file/text.ts
@@ -3,17 +3,20 @@ export const getNewline = (): string => {
   return window.navigator.platform.startsWith('Win') ? '\r\n' : '\n';
 };
 
-interface ExportAsTextFileProps<T> {
+interface ExportAsTextFileProps {
   fileName: string;
-  data: T;
+  text: string;
 }
 
-export function exportAsTextFile<T>({ fileName, data }: ExportAsTextFileProps<T>) {
-  const fileData = typeof data === 'object' ? JSON.stringify(data) : String(data);
-  const blob = new Blob([fileData], { type: 'text/plain' });
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement('a');
-  link.download = `${fileName}.txt`;
-  link.href = url;
-  link.click();
+export function exportAsTextFile({ fileName, text }: ExportAsTextFileProps) {
+  const element = document.createElement('a');
+  element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
+  element.setAttribute('download', fileName);
+
+  element.style.display = 'none';
+  document.body.appendChild(element);
+
+  element.click();
+
+  document.body.removeChild(element);
 }

--- a/packages/shared-ui/src/components/Text/index.scss
+++ b/packages/shared-ui/src/components/Text/index.scss
@@ -3,7 +3,9 @@
 ._TEXT_ {
   font-size: $font-size-medium;
   word-wrap: break-word;
+  white-space: pre-wrap;
   line-height: 1em;
+
   &.block {
     display: block;
   }


### PR DESCRIPTION
## Implement
- Fixed text file encoding issue when downloading result
- Resolved an issue where line breaks disappeared when checking the entered value on the confirmation page