### PR TITLE
fix: Modify the string length limit in textarea to be text length

### DIFF
--- a/apps/web/src/modules/form/components/index.module.scss
+++ b/apps/web/src/modules/form/components/index.module.scss
@@ -42,18 +42,9 @@
       max-height: 200px;
       width: 100%;
       li {
-        max-width: 350px;
-        @media screen and (min-width: $breakpoint-xlarge) {
-          max-width: 650px;
-        }
-        @media screen and (min-width: $breakpoint-large) {
-          max-width: 550px;
-        }
-        @media screen and (min-width: #{$breakpoint-medium}) and (max-width: #{$breakpoint-large - 1}) {
-          max-width: 450px;
-        }
+        width: 100%;
         @media screen and (max-width: $breakpoint-xsmall) {
-          max-width: 75vw;
+          max-width: 70vw;
         }
       }
     }

--- a/apps/web/src/page.module.scss
+++ b/apps/web/src/page.module.scss
@@ -43,7 +43,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 80vw;
+  width: 50vw;
   padding: 10vh 0;
 }
 

--- a/packages/shared-ui/src/components/Textarea/index.tsx
+++ b/packages/shared-ui/src/components/Textarea/index.tsx
@@ -49,6 +49,12 @@ const Textarea = ({
   const [isFocused, setIsFocused] = React.useState(false);
   const isError = !isFocused && isNotBlank(text) && error.regex && error.regex.test(text);
 
+  const handleOnChangeText = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const value = event.target.value;
+    if (value.length > maxLength) return;
+    onChangeText(event);
+  };
+
   return (
     <div className={cn('_TEXTAREA_', className)}>
       {label.labelText && (
@@ -64,7 +70,7 @@ const Textarea = ({
           </Text>
         </div>
       )}
-      {/* In Textarea, maxLength is incorrectly applied because Unicode has a longer length than ASCII code. */}
+
       <div className="_wrapper">
         <textarea
           style={{
@@ -72,10 +78,9 @@ const Textarea = ({
             fontSize: getFontSize(text),
           }}
           className={cn({ error: isError })}
-          maxLength={maxLength}
           placeholder={placeholder}
-          value={text.slice(0, maxLength)}
-          onChange={onChangeText}
+          value={text}
+          onChange={handleOnChangeText}
           id={uid}
           name={uid}
           onFocus={() => setIsFocused(true)}


### PR DESCRIPTION
## Implement
The textarea maxLength property is set based on Unicode length.
The goal was to set the standard by text length, so if the length exceeds the limit, it was modified to prevent further input.